### PR TITLE
Fix: prevent busy loop when line is all whitespace.

### DIFF
--- a/diag_server/DiagServer.py
+++ b/diag_server/DiagServer.py
@@ -341,6 +341,8 @@ class DiagRequestHandler(SocketServer.StreamRequestHandler):
 			while line != "":
 				cmd = line.split()
 				if len(cmd) < 1:
+					# line was all whitespace.
+					line = self.rfile.readline()
 					continue
 				
 				if not handshake:


### PR DESCRIPTION
When run on a string with all whitespace, python's default `split` returns an empty list.

The empty list causes `len(cmd)` to be zero, and the original code continued the loop without changing the value of `line`, which caused a busy loop.

This change ignores the whitespace and reads the next line before continuing.
